### PR TITLE
lock down express version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git://github.com/achingbrain/pm2-web.git"
 	},
 	"dependencies": {
-		"express": "^3.4",
+		"express": ">=3.4 <=3.15.2",
 		"jade": "^1.1",
 		"winston": "^0.7",
 		"underscore.string": "^2.3",


### PR DESCRIPTION
express.js had been sold/transferred to people who has no knowledge of how it works internally, so there is a concern that future updates will do more harm than good.

`3.15.2` will likely be last version of express 3.x as we know it, so I suggest to just lock to that.

Current express.js has no critical bugs, so there is no rush to change anything. I just propose to stop automatic updates until that thing gets resolved.
