### PR TITLE
quote node.js versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
- - 0.10
+ - "0.10"
 script: npm run coveralls


### PR DESCRIPTION
See visionmedia/mocha@a8c67e9 .

YAML parses `0.10` as "0.1", so without quotes it could cause trouble.
