### PR TITLE
use ansi-html instead of ansi-to-html, ~11x faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"zepto-browserify": "^1.0",
 		"moment": "^2.5",
 		"mustache": "^0.8",
-		"ansi-to-html": "^0.2",
+		"ansi-html": "~0.0.4",
 		"html-entities": "^1.0",
 		"method-override": "^2.1.2"
 	},

--- a/ui/filters/ansiToHtml.js
+++ b/ui/filters/ansiToHtml.js
@@ -1,13 +1,16 @@
-var Convert = require("ansi-to-html"),
+var ansiHTML = require("ansi-html"),
 	Entities = require("html-entities").XmlEntities;
 
-var convert = new Convert();
 var entities = new Entities();
 
 module.exports = ["$sce", function($sce) {
+
+	// don't force background color
+	ansiHTML.tags.open[0] = ansiHTML.tags.open[0].replace("color:#000;", "");
+
 	return function(text) {
 		var encoded = entities.encode(text);
 
-		return $sce.trustAsHtml(convert.toHtml(encoded));
+		return $sce.trustAsHtml(ansiHTML(encoded));
 	}
 }];


### PR DESCRIPTION
Fixes one of the heaviest CPU consumers (for me).

Found with Chrome's profiling tools and then ran some benchmarks.

Here are the results:
```console
± node ansiToHtml.js 
typeObject ansi-html x 54.46 ops/sec ±2.12% (60 runs sampled)
typeObject ansi-to-html x 5.33 ops/sec ±2.94% (17 runs sampled)
typeObject ansi_up (styles) x 1.01 ops/sec ±1.08% (7 runs sampled)
typeObject ansi_up (classes) x 1.04 ops/sec ±2.27% (7 runs sampled)
```

Also, here's the benchmark source code if you're interested:
```js
"use strict";
// benchmark ways to convert ansi strings to html


// setup
var ansiHTML = require("ansi-html"),
	Convert = require("ansi-to-html"),
	convert = new Convert(),
	ansiToHtmlConverter = convert.toHtml.bind(convert),
	ansi_up = require("ansi_up"),
	ansiUpToHtml = ansi_up.ansi_to_html.bind(ansi_up);
//	termio = require("termio"); -- omitted because it uses streaming so it is just a bit different

var fs = require("fs"),
	input = fs.readFileSync("./test.ansi.txt",{encoding:"ascii"}),
	Entities = require("html-entities").XmlEntities,
	entities = new Entities(),
	encoded = entities.encode(input),
	output = "";


// tests
exports.ansiToHtml = {

	"ansi-html": function() {
		output = ansiHTML(encoded);
	},

	"ansi-to-html": function() {
		output = ansiToHtmlConverter(encoded);
	},

	"ansi_up (styles)": function() {
		output = ansiUpToHtml(encoded);
	},
	"ansi_up (classes)": function() {
		output = ansiUpToHtml(encoded, {use_classes:true});
	},

};


// if run directly run benchmarks
if (!module.main) require("benchmarksman").runner(exports);
```