### PR TITLE
Running in subfolder

### DIFF
--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -7,20 +7,19 @@ html(lang='en', ng-app='pm2-web')
       var settings = {
         version: '#{version}'
       };
-    script(type='text/javascript', src='/js/vendor/angular/angular.js')
-    script(type='text/javascript', src='/js/vendor/angular/angular-route.js')
-    script(type='text/javascript', src='/js/vendor/angular/angular-sanitize.js')
-    script(type='text/javascript', src='/js/vendor/bootstrap/ui-bootstrap-tpls-0.7.0.min.js')
-    script(type='text/javascript', src='/js/vendor/reconnecting-websocket/reconnecting-websocket.min.js')
-    script(type='text/javascript', src='/js/vendor/highcharts/highcharts-all.js')
-    script(type='text/javascript', src='/js/vendor/highcharts-ng/highcharts-ng.min.js')
-    script(type='text/javascript', src='/js/monitor.js')
-    link(rel='stylesheet', href='/css/reset.css')
-    link(rel='stylesheet', href='/css/bootstrap.css')
-    link(rel='stylesheet', href='/css/style.css')
-    link(rel='icon', type='image/png', href='/img/favicon.png')
+    script(type='text/javascript', src='js/vendor/angular/angular.js')
+    script(type='text/javascript', src='js/vendor/angular/angular-route.js')
+    script(type='text/javascript', src='js/vendor/angular/angular-sanitize.js')
+    script(type='text/javascript', src='js/vendor/bootstrap/ui-bootstrap-tpls-0.7.0.min.js')
+    script(type='text/javascript', src='js/vendor/reconnecting-websocket/reconnecting-websocket.min.js')
+    script(type='text/javascript', src='js/vendor/highcharts/highcharts-all.js')
+    script(type='text/javascript', src='js/vendor/highcharts-ng/highcharts-ng.min.js')
+    script(type='text/javascript', src='js/monitor.js')
+    link(rel='stylesheet', href='css/reset.css')
+    link(rel='stylesheet', href='css/bootstrap.css')
+    link(rel='stylesheet', href='css/style.css')
+    link(rel='icon', type='image/png', href='img/favicon.png')
   body
     article(ng-view)
     footer(ng-controller='FooterController')
       small pm2-web version {{version}}
-

--- a/ui/routes.js
+++ b/ui/routes.js
@@ -3,10 +3,10 @@ module.exports = ["$routeProvider",
 	function($routeProvider) {
 		$routeProvider.
 			when("/hosts/:host", {
-				templateUrl: "/js/partials/host.html"
+				templateUrl: "js/partials/host.html"
 			}).
 			otherwise({
-				templateUrl: "/js/partials/connecting.html",
+				templateUrl: "js/partials/connecting.html",
 				controller: "ConnectionController"
 			});
 	}


### PR DESCRIPTION
Absolute asset urls switched to relative. 
Allows running the app behind proxy in a subfolder. Fixes issue achingbrain/pm2-web#45.

Related to: achingbrain/pm2-web#9

Tests do not pass and I'm not sure why. If you however compile the app yourself, you can see it works:

```
npm install -g grunt-cli
grunt browserify
```

Using this nginx config, I am able to run the app in subfolder:

```
http {

  map $http_upgrade $connection_upgrade {
      default upgrade;
      '' close;
  }

  upstream pm2-web {
    server 127.0.0.1:9000;
  }

  server {
    listen       8080;
    server_name  localhost;

    # assets
    location /pm2-web {
      proxy_pass        http://pm2-web/;
      proxy_redirect    off;
      proxy_set_header  Host $host;
      proxy_set_header   X-Real-IP $remote_addr;
      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header   X-Forwarded-Host $server_name;
    }

    # websockets
    location /ws {
        proxy_pass http://pm2-web;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection $connection_upgrade;
    }
  }
}
```
